### PR TITLE
Fix typescript definition.  

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jslinq",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Another LINQ provider for Javascript",
   "main": "src/jslinq.js",
   "author": "maurobussini",
@@ -8,16 +8,16 @@
     "type": "git",
     "url": "https://github.com/maurobussini/jslinq.git"
   },
-  "scripts": { 
-    "test": "karma start karma.conf.js", 
+  "scripts": {
+    "test": "karma start karma.conf.js",
     "build": "gulp build"
   },
   "keywords": [
     "linq",
     "json",
     "query",
-    "array", 
-    "ng2", 
+    "array",
+    "ng2",
     "angular2"
   ],
   "license": "MIT",

--- a/src/jslinq.d.ts
+++ b/src/jslinq.d.ts
@@ -20,7 +20,7 @@ declare namespace jslinq {
         toList?: () => T[];
 
         //Intersect
-        intersect?: (otherData: T[], comparisonField?: (el) => T) => JsLinq<T>;
+        intersect?: (otherData: T[], comparisonField?: (el: T) => T) => JsLinq<T>;
 
         //Distinct
         distinct?: () => JsLinq<T>;


### PR DESCRIPTION
Build fails with TS7006 error when noImplicitAny tsconfig is set to true.  

```
node_modules/jslinq/src/jslinq.d.ts:23:57 - error TS7006: Parameter 'el' implicitly has an 'any' type.

23         intersect?: (otherData: T[], comparisonField?: (el) => T) => JsLinq<T>;
```

Bump version number and add type declaration to element.